### PR TITLE
fix(components): [timeline-item] fix wrapper cover the icon

### DIFF
--- a/packages/theme-chalk/src/timeline-item.scss
+++ b/packages/theme-chalk/src/timeline-item.scss
@@ -8,7 +8,7 @@
 
   @include e(wrapper) {
     position: relative;
-    padding-left: 28px;
+    margin-left: 28px;
     top: -3px;
   }
 


### PR DESCRIPTION
当 timeline-item 的自定义 `icon` 设置了 `title` 属性后（或者图标组件自定义了其他需要鼠标移入触发的事件），由于 wrapper 元素将 icon 覆盖导致 `title` 属性无法触发提示

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
